### PR TITLE
Use static branching to replace the individual download targets

### DIFF
--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -7,7 +7,7 @@ get_site_data <- function(sites_info, state, parameter) {
   # simulate an unreliable web service or internet connection by causing random failures
   set.seed(Sys.time()) # Make sure that the seed changes with every run (targets likes to store the seed)
   if(runif(1) < 0.5) {
-    Sys.sleep(2)
+    Sys.sleep(0.5)
     stop('Ugh, the internet data transfer failed! Try again.')
   }
 

--- a/_targets.R
+++ b/_targets.R
@@ -1,5 +1,6 @@
-
 library(targets)
+library(tarchetypes)
+library(tibble)
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr", "rnaturalearth", "cowplot"))
@@ -10,7 +11,7 @@ source("1_fetch/src/get_site_data.R")
 source("3_visualize/src/map_sites.R")
 
 # Configuration
-states <- c('WI','MN','MI')
+states <- c('WI', 'MN', 'MI', 'IL')
 parameter <- c('00060')
 
 # Targets
@@ -19,23 +20,13 @@ list(
   tar_target(oldest_active_sites, find_oldest_sites(states, parameter)),
 
   # PULL SITE DATA HERE
-  tar_target(
-    wi_data,
-    get_site_data(sites_info = oldest_active_sites,
-                  state = "WI",
-                  parameter = parameter)
-  ),
-  tar_target(
-    mn_data,
-    get_site_data(sites_info = oldest_active_sites,
-                  state = "MN",
-                  parameter = parameter)
-  ),
-  tar_target(
-    mi_data,
-    get_site_data(sites_info = oldest_active_sites,
-                  state = "MI",
-                  parameter = parameter)
+  tar_map(
+    values = tibble(state_abb = states),
+    tar_target(nwis_data, get_site_data(sites_info = oldest_active_sites,
+                                        state = state_abb,
+                                        parameter = parameter))
+    # Insert step for tallying data here
+    # Insert step for plotting data here
   ),
 
   # Map oldest sites


### PR DESCRIPTION
The pipeline now uses static branching instead of individual targets for each state.