### PR TITLE
use a splitter on oldest_active_sites

### DIFF
--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,7 +1,6 @@
 # download data for each site
 # packages needed: tidyverse, dataRetrieval
-get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
+get_site_data <- function(site_info, state, parameter) {
   message(sprintf('  Retrieving data for %s-%s', state, state))
 
   # simulate an unreliable web service or internet connection by causing random failures

--- a/_targets.R
+++ b/_targets.R
@@ -11,7 +11,7 @@ source("1_fetch/src/get_site_data.R")
 source("3_visualize/src/map_sites.R")
 
 # Configuration
-states <- c('WI', 'MN', 'MI', 'IL')
+states <- c('WI', 'MN', 'MI', 'IL', 'IN', 'IA')
 parameter <- c('00060')
 
 # Targets
@@ -22,7 +22,9 @@ list(
   # PULL SITE DATA HERE
   tar_map(
     values = tibble(state_abb = states),
-    tar_target(nwis_data, get_site_data(sites_info = oldest_active_sites,
+    tar_target(nwis_inventory,
+               filter(oldest_active_sites, state_cd == state_abb) ),
+    tar_target(nwis_data, get_site_data(site_info = nwis_inventory,
                                         state = state_abb,
                                         parameter = parameter))
     # Insert step for tallying data here


### PR DESCRIPTION
The pipeline now uses a splitter to avoid having to redo all of the `nwis_data_xx()` calls every time a new state is added.

When IA and IN are added to the states list, the `nwis_inventory_xx()` is still run for every state, because `find_oldest_sites()` is mapping over a different list of states. This function is pretty reliable and doesn't take terribly long, but if we're going to be adding a lot of states gradually, then it might make sense to move the map logic out of `find_oldest_sites()` and let it be managed with a splitter by `targets`.

The `nwis_data_xx` calls are only run for the new states (IA and IN), as desired.